### PR TITLE
flag-checking-updates changed missing flag errors

### DIFF
--- a/flagon.gemspec
+++ b/flagon.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'flagon'
-  s.version     = '1.0.4'
+  s.version     = '2.0.0'
   s.date        = '2015-02-12'
   s.summary     = 'A feature flag gem'
   s.description = 'A gem for managing feature flags either with environemnt variables or config files'

--- a/lib/flagon.rb
+++ b/lib/flagon.rb
@@ -36,6 +36,11 @@ module Flagon
       @inspector.when_enabled(flag_name, &block)
     end
 
+    def ensure_flags_exist(*flags)
+      check_initialized
+      @inspector.ensure_flags_exist(*flags)
+    end
+
     private
 
     def check_initialized

--- a/lib/flagon/inspector.rb
+++ b/lib/flagon/inspector.rb
@@ -7,7 +7,7 @@ module Flagon
     end
 
     def enabled?(flag_name)
-      raise FlagMissing, "The flag #{flag_name} is missing" unless exists?(flag_name)
+      return false unless exists?(flag_name)
       get_flag(flag_name)
     end
 
@@ -15,6 +15,13 @@ module Flagon
       if enabled?(flag_name)
         yield
       end
+    end
+
+    def ensure_flags_exist(*flags)
+      missing_flags = flags.select do |flag_name|
+        !exists?(flag_name)
+      end
+      raise FlagMissing, "The following flags are missing: #{missing_flags.join(', ')}" unless missing_flags.empty?
     end
 
     class FlagMissing < Exception

--- a/spec/flagon/inspector_spec.rb
+++ b/spec/flagon/inspector_spec.rb
@@ -8,17 +8,28 @@ describe Flagon::Inspector do
     expect(subject.enabled?(:a_flag)).to be true
   end
 
-  it "raises an exception on a missing flag" do
-    allow(loader).to receive(:exists?).and_return false
-    expect{subject.enabled?(:missing_flag)}.
-      to raise_exception described_class::FlagMissing, "The flag missing_flag is missing"
-  end
-
-  it "can execute a block if the flag exists" do
+  it "can execute a block if the flag is enabled" do
     test_object = double(:test_object)
     expect(test_object).to receive(:hello)
     subject.when_enabled(:a_flag) do
       test_object.hello
     end
+  end
+
+  it "returns false by default if a flag doesn't exist" do
+    allow(loader).to receive(:exists?).and_return false
+    expect(subject.enabled?(:a_flag)).to be false
+  end
+
+  it "can ensure a flag exists" do
+    allow(loader).to receive(:exists?).and_return false
+    expect{subject.ensure_flags_exist(:missing_flag)}.
+      to raise_exception described_class::FlagMissing, "The following flags are missing: missing_flag"
+  end
+
+  it "can ensure multiple flags exist" do
+    allow(loader).to receive(:exists?).and_return false
+    expect{subject.ensure_flags_exist(:missing_flag, :another_missing_flag)}.
+      to raise_exception described_class::FlagMissing, "The following flags are missing: missing_flag, another_missing_flag"
   end
 end

--- a/spec/flagon_spec.rb
+++ b/spec/flagon_spec.rb
@@ -66,4 +66,21 @@ describe Flagon do
       described_class.when_enabled(:something) {}
     end
   end
+
+  context "ensure_flags_exist" do
+    before do
+      described_class.instance_variable_set(:@inspector, nil)
+    end
+
+    it "raises an error if flagon isn't initialized" do
+      expect{described_class.ensure_flags_exist(:something)}.
+        to raise_exception(described_class::NotInitialized)
+    end
+
+    it "calls the instance after it is initialized" do
+      inspector = described_class.init
+      expect(inspector).to receive(:ensure_flags_exist)
+      described_class.ensure_flags_exist(:something)
+    end
+  end
 end

--- a/spec/flagon_spec.rb
+++ b/spec/flagon_spec.rb
@@ -79,7 +79,7 @@ describe Flagon do
 
     it "calls the instance after it is initialized" do
       inspector = described_class.init
-      expect(inspector).to receive(:ensure_flags_exist)
+      expect(inspector).to receive(:ensure_flags_exist).with(:something)
       described_class.ensure_flags_exist(:something)
     end
   end


### PR DESCRIPTION
- removed runtime errors when checking flags, returned false instead
- added a method to ensure the existance of specified flags that can be
  used by apps after initialize
